### PR TITLE
add Windows equivalent for .env copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This repo is inteded for use with Python 3.9
    - Create a `.env` file in the project root directory
 
    ```
-   cp .env.example .env
+   cp .env.example .env  # Windows: copy .env.example .env
    ```
 
    - Add the following environment variables:


### PR DESCRIPTION
Add a Windows equivalent (copy) for the .env setup command in the README to make onboarding smoother for Windows users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Windows 'copy' alternative to the .env setup command in README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c83a9c4e28813256e44d33e2f3fe49c3fd94a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->