### PR TITLE
Fix incorrect method name in get_events

### DIFF
--- a/agents/polymarket/gamma.py
+++ b/agents/polymarket/gamma.py
@@ -112,7 +112,7 @@ class GammaMarketClient:
             else:
                 events: list[PolymarketEvent] = []
                 for market_event_obj in data:
-                    events.append(self.parse_event(market_event_obj))
+                    events.append(self.parse_pydantic_event(market_event_obj))
                 return events
         else:
             raise Exception()


### PR DESCRIPTION
Fixes #35. The get_events method was calling parse_event which does not exist. Changed to parse_pydantic_event to match the actual method name defined in the GammaMarketClient class.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line fix to call the correct event parser; low risk aside from potentially changing returned event object shape when `parse_pydantic=True`.
> 
> **Overview**
> Fixes a broken code path in `GammaMarketClient.get_events` where the pydantic parsing branch called a non-existent `parse_event` method.
> 
> When `parse_pydantic=True`, events are now parsed via `parse_pydantic_event`, preventing runtime errors and returning `PolymarketEvent` instances as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b18afc724fca524bc23d1f86b4762cf590345550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->