### PR TITLE
Bound retry loop in Trader.one_best_trade

### DIFF
--- a/agents/application/trade.py
+++ b/agents/application/trade.py
@@ -24,7 +24,7 @@ class Trader:
         except:
             pass
 
-    def one_best_trade(self) -> None:
+    def one_best_trade(self, max_retries: int = 3) -> None:
         """
 
         one_best_trade is a strategy that evaluates all events, markets, and orderbooks
@@ -34,35 +34,42 @@ class Trader:
         then executes that trade without any human intervention
 
         """
-        try:
-            self.pre_trade_logic()
+        retries_remaining = max(0, max_retries)
 
-            events = self.polymarket.get_all_tradeable_events()
-            print(f"1. FOUND {len(events)} EVENTS")
+        while True:
+            try:
+                self.pre_trade_logic()
 
-            filtered_events = self.agent.filter_events_with_rag(events)
-            print(f"2. FILTERED {len(filtered_events)} EVENTS")
+                events = self.polymarket.get_all_tradeable_events()
+                print(f"1. FOUND {len(events)} EVENTS")
 
-            markets = self.agent.map_filtered_events_to_markets(filtered_events)
-            print()
-            print(f"3. FOUND {len(markets)} MARKETS")
+                filtered_events = self.agent.filter_events_with_rag(events)
+                print(f"2. FILTERED {len(filtered_events)} EVENTS")
 
-            print()
-            filtered_markets = self.agent.filter_markets(markets)
-            print(f"4. FILTERED {len(filtered_markets)} MARKETS")
+                markets = self.agent.map_filtered_events_to_markets(filtered_events)
+                print()
+                print(f"3. FOUND {len(markets)} MARKETS")
 
-            market = filtered_markets[0]
-            best_trade = self.agent.source_best_trade(market)
-            print(f"5. CALCULATED TRADE {best_trade}")
+                print()
+                filtered_markets = self.agent.filter_markets(markets)
+                print(f"4. FILTERED {len(filtered_markets)} MARKETS")
 
-            amount = self.agent.format_trade_prompt_for_execution(best_trade)
-            # Please refer to TOS before uncommenting: polymarket.com/tos
-            # trade = self.polymarket.execute_market_order(market, amount)
-            # print(f"6. TRADED {trade}")
+                market = filtered_markets[0]
+                best_trade = self.agent.source_best_trade(market)
+                print(f"5. CALCULATED TRADE {best_trade}")
 
-        except Exception as e:
-            print(f"Error {e} \n \n Retrying")
-            self.one_best_trade()
+                amount = self.agent.format_trade_prompt_for_execution(best_trade)
+                # Please refer to TOS before uncommenting: polymarket.com/tos
+                # trade = self.polymarket.execute_market_order(market, amount)
+                # print(f"6. TRADED {trade}")
+                return
+
+            except Exception as e:
+                if retries_remaining == 0:
+                    raise
+
+                print(f"Error {e} \n \n Retrying")
+                retries_remaining -= 1
 
     def maintain_positions(self):
         pass

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -1,0 +1,60 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def load_trade_module():
+    sys.modules.pop("agents.application.trade", None)
+
+    executor_module = types.ModuleType("agents.application.executor")
+    gamma_module = types.ModuleType("agents.polymarket.gamma")
+    polymarket_module = types.ModuleType("agents.polymarket.polymarket")
+
+    class Executor:
+        pass
+
+    class GammaMarketClient:
+        pass
+
+    class Polymarket:
+        pass
+
+    executor_module.Executor = Executor
+    gamma_module.GammaMarketClient = GammaMarketClient
+    polymarket_module.Polymarket = Polymarket
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "agents.application.executor": executor_module,
+            "agents.polymarket.gamma": gamma_module,
+            "agents.polymarket.polymarket": polymarket_module,
+        },
+    ):
+        return importlib.import_module("agents.application.trade")
+
+
+class TraderRetryTests(unittest.TestCase):
+    def test_one_best_trade_raises_original_error_after_bounded_retries(self):
+        trade_module = load_trade_module()
+        trader = trade_module.Trader.__new__(trade_module.Trader)
+
+        attempts = {"count": 0}
+
+        def always_fail():
+            attempts["count"] += 1
+            raise RuntimeError("boom")
+
+        trader.pre_trade_logic = always_fail
+
+        with mock.patch("builtins.print"):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                trader.one_best_trade(max_retries=2)
+
+        self.assertEqual(attempts["count"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the recursive retry path in `Trader.one_best_trade()` with a bounded loop
- re-raise the original exception once retries are exhausted instead of recursing indefinitely
- add a regression test covering repeated failure and bounded retries

## Why
During repo-audit, `Trader.one_best_trade()` was found to call itself from the `except` block. If the underlying failure persists, the method keeps recursing until Python hits the recursion limit, which hides the original operational error behind a secondary `RecursionError`.

## Testing
- `/Users/soth/工作空间/githubfix/.venv/bin/python -m unittest discover -s tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main trading execution path by changing retry/error propagation semantics; mistakes could alter how failures are surfaced or how many times trade selection runs.
> 
> **Overview**
> **Bounds retry behavior in `Trader.one_best_trade()`.** The method now accepts `max_retries`, retries via a loop instead of self-recursion, and re-raises the original exception once the retry budget is exhausted.
> 
> Adds a unit test (`tests/test_trade.py`) that simulates repeated failure and asserts the function attempts `max_retries + 1` times and ultimately raises the original error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9a85a4545ae38ecd265a2de516ab486af87530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->